### PR TITLE
Changed to curl to prevent ssl error ubermuda/docker-composer#1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian:jessie
 
 RUN apt-get update
-RUN apt-get install -y php5-cli php5-json
-RUN php -r "readfile('https://getcomposer.org/installer');" | php
+RUN apt-get install -y php5-cli php5-json curl
+
+RUN curl -sS https://getcomposer.org/installer | php
 
 VOLUME ["/srv"]
 WORKDIR /srv


### PR DESCRIPTION
In the base installation there not the necessary ssl certificates available to download composer via php readfile. So I have changed the Dockerfile to use curl instead. Because the installation of curl also install the required certificates.